### PR TITLE
change initial animation state for graphs to not do animation on comp…

### DIFF
--- a/src/components/DataStructures/Graph/GraphRenderer/index.js
+++ b/src/components/DataStructures/Graph/GraphRenderer/index.js
@@ -216,6 +216,7 @@ class GraphRenderer extends Renderer {
           return (
             <motion.g
               animate={{ x, y }}
+              initial={false}
               transition={{ duration: 1 }}
               className={classes(
                 styles.node,


### PR DESCRIPTION
Should stop the nodes flying everywhere when you open up the animation screen. Very minor change.