### PR TITLE
fix: reduce min width of array elements so they don't run off screen

### DIFF
--- a/src/components/DataStructures/Array/Array2DRenderer/Array2DRenderer.module.scss
+++ b/src/components/DataStructures/Array/Array2DRenderer/Array2DRenderer.module.scss
@@ -12,7 +12,8 @@
     .col {
       display: table-cell;
       text-align: center;
-      min-width: 28px;
+      min-width: 8px;
+      width: 28px;
       background-color: var(--array-2d-row-col-bg);
       border: 1px solid var(--array-2d-row-col-border);
       padding: 0 4px;


### PR DESCRIPTION
Simply reduces the min-width so that array items can automatically reduce in width.

ref: BR_1