### PR TITLE
fix: safari display bug for array background clipping

### DIFF
--- a/src/components/DataStructures/Array/Array2DRenderer/index.js
+++ b/src/components/DataStructures/Array/Array2DRenderer/index.js
@@ -104,7 +104,7 @@ class Array2DRenderer extends Renderer {
                     borderRight: '0',
                     borderTop: `${this.toString(scaleY(largestColumnValue - col.value))}px rgba(0,0,0,0) solid`,
                     borderBottom: 0,
-                    backgroundClip: 'content-box',
+                    backgroundClip: 'padding-box',
                     padding: '0',
                     position: 'relative',
                   }}


### PR DESCRIPTION
This fixes a very minor bug where arrays looked weird in safari.

ref: BR_3