### PR TITLE
fix: remove redundant instructions from mid panel

### DIFF
--- a/src/components/mid-panel/index.js
+++ b/src/components/mid-panel/index.js
@@ -1,35 +1,34 @@
-import React, { useContext, useEffect } from 'react';
-import PropTypes from 'prop-types';
-import { GlobalContext } from '../../context/GlobalState';
-import '../../styles/MidPanel.scss';
-import { increaseFontSize, setFontSize } from '../top/helper';
-import Instruction from './Instruction';
-
+import React, { useContext, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import { GlobalContext } from '../../context/GlobalState'
+import '../../styles/MidPanel.scss'
+import { increaseFontSize, setFontSize } from '../top/helper'
 
 function MidPanel({ fontSize, fontSizeIncrement }) {
-  const { algorithm } = useContext(GlobalContext);
-  const fontID = 'algorithmTitle';
+  const { algorithm } = useContext(GlobalContext)
+  const fontID = 'algorithmTitle'
   useEffect(() => {
-    setFontSize(fontID, fontSize);
-    increaseFontSize(fontID, fontSizeIncrement);
-  }, [fontSize, fontSizeIncrement]);
+    setFontSize(fontID, fontSize)
+    increaseFontSize(fontID, fontSizeIncrement)
+  }, [fontSize, fontSizeIncrement])
 
   return (
     <div className="midPanelContainer">
       <div className="midPanelHeader">
-        <div className="algorithmTitle" id={fontID}>{algorithm.name}</div>
+        <div className="algorithmTitle" id={fontID}>
+          {algorithm.name}
+        </div>
       </div>
       <div className="midPanelBody">
-        <Instruction instructions={algorithm.instructions} />
-        {algorithm.chunker && algorithm.chunker.getVisualisers().map((o) => o.render())}
+        {algorithm.chunker &&
+          algorithm.chunker.getVisualisers().map((o) => o.render())}
       </div>
     </div>
-  );
+  )
 }
 
-
-export default MidPanel;
+export default MidPanel
 MidPanel.propTypes = {
   fontSize: PropTypes.number.isRequired,
   fontSizeIncrement: PropTypes.number.isRequired,
-};
+}


### PR DESCRIPTION
These instructions are immediately hidden upon algorithm load now, but cause the 'flash' for a few hundred ms.

ref: BR_4