### PR TITLE
fix BR_11: incorrect text colour next to radio buttons on BST and QS

### DIFF
--- a/src/algorithms/parameters/BSTParam.js
+++ b/src/algorithms/parameters/BSTParam.js
@@ -149,7 +149,7 @@ function BSTParam() {
           setMessage={setMessage}
         />
       </div>
-      Choose type of tree: &nbsp;&nbsp;
+      <span className="generalText">Choose type of tree: &nbsp;&nbsp;</span>
       <FormControlLabel
         control={
           <BlueRadio

--- a/src/algorithms/parameters/QSM3Param.js
+++ b/src/algorithms/parameters/QSM3Param.js
@@ -67,7 +67,7 @@ function QuicksortM3Param() {
           setMessage={setMessage}
         />
       </div>
-      Choose pivot using : &nbsp;&nbsp;
+      <span className="generalText">Choose pivot using : &nbsp;&nbsp;</span>
       {/* create a checkbox for Rightmost */}
       <FormControlLabel
         control={

--- a/src/algorithms/parameters/QSParam.js
+++ b/src/algorithms/parameters/QSParam.js
@@ -10,7 +10,7 @@ import { GlobalActions } from '../../context/actions'
 import ListParam from './helpers/ListParam'
 import '../../styles/Param.scss'
 
-const DEFAULT_ARR = genRandNumList(8, 1, 99)
+const DEFAULT_ARR = genRandNumList(12, 1, 99)
 const QUICK_SORT = 'Quick Sort'
 const QUICK_SORT_EXAMPLE = 'Please follow the example provided: 0,1,2,3,4'
 const UNCHECKED = {
@@ -67,7 +67,7 @@ function QuicksortParam() {
           setMessage={setMessage}
         />
       </div>
-      Choose pivot using : &nbsp;&nbsp;
+      <span className="generalText">Choose pivot using : &nbsp;&nbsp;</span>
       {/* create a checkbox for Rightmost */}
       <FormControlLabel
         control={

--- a/src/styles/Param.scss
+++ b/src/styles/Param.scss
@@ -185,3 +185,7 @@
 .greyRoundBtnDisabled:active {
   background: none;
 }
+
+.generalText {
+  color: var(--mid-control-font);
+}


### PR DESCRIPTION
Should now style the text next to the radio buttons as white in dark mode, black in light mode.

ref: BR_11