### PR TITLE
fix BR_13: change BST graph to use more horizontal space

### DIFF
--- a/src/components/DataStructures/Graph/GraphTracer.js
+++ b/src/components/DataStructures/Graph/GraphTracer.js
@@ -458,7 +458,7 @@ class GraphTracer extends Tracer {
 
     // Calculates node's x and y.
     // adjust hGap to some function of node number later//
-    const hGap = 80;
+    const hGap = rect.width - 150;
     const vGap = rect.height / maxDepth;
     marked = {};
     const recursivePosition = (node, h, v) => {


### PR DESCRIPTION
Still based on a magic number, just a bigger one.
Calculating the width for both left and right is possible but this should be alright for now.

ref: BR_13